### PR TITLE
Quay 3.3

### DIFF
--- a/roles/quay/tasks/main.yml
+++ b/roles/quay/tasks/main.yml
@@ -77,5 +77,8 @@
         source: community-operators
         sourceNamespace: openshift-marketplace
 
-- name: Install and configure Quay Bridge operator
-  include_tasks: quay_bridge.yml
+# Disabled for now until Quay API becomes more useful for automating Bridge
+#   setup/prerequisites.
+#
+# - name: Install and configure Quay Bridge operator
+#   include_tasks: quay_bridge.yml

--- a/roles/quay/tasks/main.yml
+++ b/roles/quay/tasks/main.yml
@@ -76,3 +76,6 @@
         name: container-security-operator
         source: community-operators
         sourceNamespace: openshift-marketplace
+
+- name: Install and configure Quay Bridge operator
+  include_tasks: quay_bridge.yml

--- a/roles/quay/tasks/quay_bridge.yml
+++ b/roles/quay/tasks/quay_bridge.yml
@@ -1,0 +1,16 @@
+---
+- name: Subscribe to quay-bridge operator
+  k8s:
+    kubeconfig: '{{ kubeconfig }}'
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: quay-bridge-operator
+        namespace: openshift-operators
+      spec:
+        channel: quay-v3.3
+        installPlanApproval: Automatic
+        name: quay-bridge-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace

--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -59,8 +59,8 @@
   metadata:
     name: quay-tls-certs
     namespace: quay-enterprise
-  type: Opaque
+  type: kubernetes.io/tls
   data:
-    tls.cert: {{ lookup("file", certificate_path + "/quay-fullchain.pem")|b64encode }}
+    tls.crt: {{ lookup("file", certificate_path + "/quay-fullchain.pem")|b64encode }}
     tls.key: {{ lookup("file", certificate_path + "/quay-key.pem")|b64encode }}
 {% endif %}

--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -61,6 +61,6 @@
     namespace: quay-enterprise
   type: Opaque
   data:
-    ssl.cert: {{ lookup("file", certificate_path + "/quay-fullchain.pem")|b64encode }}
-    ssl.key: {{ lookup("file", certificate_path + "/quay-key.pem")|b64encode }}
+    tls.cert: {{ lookup("file", certificate_path + "/quay-fullchain.pem")|b64encode }}
+    tls.key: {{ lookup("file", certificate_path + "/quay-key.pem")|b64encode }}
 {% endif %}

--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -21,12 +21,12 @@
 - apiVersion: operators.coreos.com/v1alpha1
   kind: Subscription
   metadata:
-    name: quay-enterprise
+    name: quay-operator
     namespace: quay-enterprise
   spec:
-    channel: stable
+    channel: quay-v3.3
     installPlanApproval: Automatic
-    name: quay
+    name: quay-operator
     source: community-operators
     sourceNamespace: openshift-marketplace
 

--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -27,7 +27,7 @@
     channel: quay-v3.3
     installPlanApproval: Automatic
     name: quay-operator
-    source: community-operators
+    source: redhat-operators
     sourceNamespace: openshift-marketplace
 
 # Secret required to pull from quay.io

--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -11,7 +11,8 @@ spec:
     externalAccess:
       hostname: {{ quay_route }}
 {% if (use_real_certs|default(true)) %}
-    sslCertificatesSecretName: quay-tls-certs
+      tls:
+        secretName: quay-tls-certs
 {% endif %}
     imagePullSecretName: dummy-pull-secret
     superuserCredentialsSecretName: quay-superuser

--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -8,7 +8,8 @@ spec:
     enabled: true
     imagePullSecretName: dummy-pull-secret
   quay:
-    hostname: {{ quay_route }}
+    externalAccess:
+      hostname: {{ quay_route }}
 {% if (use_real_certs|default(true)) %}
     sslCertificatesSecretName: quay-tls-certs
 {% endif %}

--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -13,6 +13,7 @@ spec:
 {% if (use_real_certs|default(true)) %}
       tls:
         secretName: quay-tls-certs
+        termination: passthrough
 {% endif %}
     imagePullSecretName: dummy-pull-secret
     superuserCredentialsSecretName: quay-superuser


### PR DESCRIPTION
Closes #42 
Bump to Quay 3.3 and the official operator instead of the community tech-preview operator.

Quay bridge operator currently disabled from deployment as Quay API doesn't provide a mechanism to generate application-specific OAuth tokens, only robot tokens which are inadequate for this integration.

Would like more eyes on this before merge, @akochnev . Thanks much!