### PR TITLE
Updated quay operator version and CR

### DIFF
--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -24,10 +24,10 @@
     name: quay-enterprise
     namespace: quay-enterprise
   spec:
-    channel: stable
+    channel: quay-v3.3
     installPlanApproval: Automatic
-    name: quay
-    source: community-operators
+    name: quay-operator
+    source: redhat-operators
     sourceNamespace: openshift-marketplace
 
 # Secret required to pull from quay.io

--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -8,7 +8,8 @@ spec:
     enabled: true
     imagePullSecretName: dummy-pull-secret
   quay:
-    hostname: {{ quay_route }}
+    externalAccess:
+      hostname: {{ quay_route }}
 {% if (use_real_certs|default(true)) %}
     sslCertificatesSecretName: quay-tls-certs
 {% endif %}


### PR DESCRIPTION
Updated quay operator version to the redhat provided one together with the specific version that is available in OCP 4.4. Also updated the quay CR to properly use the hostname based on the updated schema in order to have the route to use the correct hostname

Without this fix the subscription to the quay operator no longer works. Without the hostname fix, the quay operator doesn't update the route to the correct URL. 