### PR TITLE
enable quay repo mirroring

### DIFF
--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -8,6 +8,9 @@ spec:
     enabled: true
     imagePullSecretName: dummy-pull-secret
   quay:
+{% if (enable_quay_repo_mirroring|default(false)) %}
+    enableRepoMirroring: true
+{% endif %}
     externalAccess:
       hostname: {{ quay_route }}
 {% if (use_real_certs|default(true)) %}

--- a/vars/devsecops.example.yml
+++ b/vars/devsecops.example.yml
@@ -60,6 +60,9 @@ github_project: jharmison-redhat
 # deploy_pipeline: no
 # deploy_workshop: no
 
+# Change quay config definition to allow mirroring of image repositories
+enable_quay_repo_mirroring: yes
+
 # Uncomment this line to deploy the bookinfo application to Service Mesh and 3scale (it defaults to NO)
 # deploy_bookinfo: yes
 


### PR DESCRIPTION
Mod quay_cr.yml to include option to enable repo-mirroring.

Results in `FEATURE_REPO_MIRROR: true` being enabled in the `quay-enterprise-config-secret` `config.yaml` value

