### PR TITLE
Container-based workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV AWS_ACCESS_KEY_ID ""
 ENV AWS_SECRET_ACCESS_KEY ""
 
 RUN dnf -y --setopt=tsflags=nodocs update && \
-    dnf -y --setopt=tsflags=nodocs install python3 python3-pip gnupg2 httpd-tools git && \
+    dnf -y --setopt=tsflags=nodocs install python3 python3-pip gnupg2 httpd-tools git openssh-clients && \
     dnf -y clean all --enablerepo='*'
 RUN curl http://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz -o /root/oc.tar.gz && \
     tar xvzf /root/oc.tar.gz -C /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ ENV AWS_SECRET_ACCESS_KEY ""
 
 RUN dnf -y --setopt=tsflags=nodocs update && \
     dnf -y --setopt=tsflags=nodocs install python3 python3-pip gnupg2 httpd-tools git && \
-    dnf -y clean all --enablerepo='*' && \
-    curl http://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz -o /root/oc.tar.gz && \
-    tar xvzf /root/oc.tar.gz -C /usr/local/bin && \
-    pip3 install --upgrade --no-cache-dir ansible openshift git+https://github.com/jharmison-redhat/devsecops-api-script.git
+    dnf -y clean all --enablerepo='*'
+RUN curl http://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz -o /root/oc.tar.gz && \
+    tar xvzf /root/oc.tar.gz -C /usr/local/bin
+RUN pip3 install --upgrade --no-cache-dir ansible openshift jmespath git+https://github.com/jharmison-redhat/devsecops-api-script.git
 
 RUN mkdir -p /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+RUN dnf -y --setopt=tsflags=nodocs update && \
+    dnf -y --setopt=tsflags=nodocs install python3 python3-pip gnupg2 httpd-tools git && \
+    dnf -y clean all --enablerepo='*' && \
+    curl http://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz -o /root/oc.tar.gz && \
+    tar xvzf /root/oc.tar.gz -C /usr/local/bin && \
+    pip3 install --upgrade --no-cache-dir ansible openshift git+https://github.com/jharmison-redhat/devsecops-api-script.git
+
+RUN mkdir -p /app
+
+COPY ansible.cfg /app/ansible.cfg
+COPY inventory /app/inventory
+COPY library /app/library
+COPY roles /app/roles
+COPY playbooks /app/playbooks
+
+# You should bind-mount your own tmp and vars dirs for playbook persistence.
+
+WORKDIR /app
+ENTRYPOINT ["ansible-playbook"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
+ENV AWS_ACCESS_KEY_ID ""
+ENV AWS_SECRET_ACCESS_KEY ""
+
 RUN dnf -y --setopt=tsflags=nodocs update && \
     dnf -y --setopt=tsflags=nodocs install python3 python3-pip gnupg2 httpd-tools git && \
     dnf -y clean all --enablerepo='*' && \

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # OpenShift DevSecOps Workshop
+
 ---
 
-### **Note**: This is a temporary README to support testing and demonstration of the status of the repository, it is not the final intended README.
+## **Note**: This is a temporary README to support testing and demonstration of the status of the repository, it is not the final intended README
 
 ## Design Goals
+
 Several design goals were set in place before this started, and they have evolved somewhat as the work has gone on.
-  - Every role should be useful outside of the context of this workshop
-  - Every interaction with OpenShift should be done via the Kubernetes API, using the Ansible `k8s` module, except where it is impractical, to best support declarative configuration and enable fault tolerance and recovery from failures.
-  - Everywhere that an action is not natively idempotent (ex: `shell` module), effort should be made to make it idempotent and report appropriate status back to Ansible.
-      (Any failures at all due to network conditions, timing problems, etc. should be 100% resolvable by running the exact same playbook without introducing new errors)
-  - Everything should be OpenShift 4.x native. This means preferring built-in functionality over third-party functionality, and it means using Operators as the primary deployment/management mechanism.
-  - There should be zero interaction required from the time you start to deploy the cluster to the time that the workshop is available for use. Anywhere that automation can make a decision about setting something up, it should have a variable available to change its behavior but assume a sane default.
-  - Readability is fundamentally important and any time that something is deemed to be too difficult to understand (large in-line Jinja or JMESPath, for example), it should be separated to be easier to understand.
+
+- Every role should be useful outside of the context of this workshop
+- Every interaction with OpenShift should be done via the Kubernetes API, using the Ansible `k8s` module, except where it is impractical, to best support declarative configuration and enable fault tolerance and recovery from failures.
+- Everywhere that an action is not natively idempotent (ex: `shell` module), effort should be made to make it idempotent and report appropriate status back to Ansible.
+   (Any failures at all due to network conditions, timing problems, etc. should be 100% resolvable by running the exact same playbook without introducing new errors)
+- Everything should be OpenShift 4.x native. This means preferring built-in functionality over third-party functionality, and it means using Operators as the primary deployment/management mechanism.
+- There should be zero interaction required from the time you start to deploy the cluster to the time that the workshop is available for use. Anywhere that automation can make a decision about setting something up, it should have a variable available to change its behavior but assume a sane default.
+- Readability is fundamentally important and any time that something is deemed to be too difficult to understand (large in-line Jinja or JMESPath, for example), it should be separated to be easier to understand.
 
 ## Supported Operating Systems
+
 Right now, `run.sh` is the primary mechanism for executing the playbooks. It provides the appropriate context and control for chaining playbooks together locally, as well as ensuring that prerequisites for the roles and playbooks are implemented on your system. You can use `run.sh` on unsupported platforms by ensuring the dependencies are met before running it, or you can use it on a supported platform to have it do the work for you.
 
 `run.sh` was developed on Fedora 30 and 31. All modern testing of it has been done on Fedora 32. The most important part of satisfying dependencies automatically is that you have `dnf` available and a Fedora-like package naming convention. This means that it should operate as expected on RHEL 8, but this has not been tested for validity.
@@ -23,7 +27,10 @@ The requirements for running the playbooks and roles have been mostly consolidat
 To run the playbooks yourself, using `ansible-playbook` and without `run.sh`, `jq` is not required but the other binaries in the `dnf` key as well as the Python libraries in the `pip` key of `runreqs.json` are all required.
 
 ## Alternative, container-based usage
-`run-container.sh` has been developed to use the Dockerfile present to run the playbooks inside a RHEL 8 UBI container image. This means you can use run-container.sh to package a new container image on the fly with your changes to the repository, satisfying dependencies, and then map tmp and vars in to the container. In order to enable multiple clusters being run with multiple containers, `run-container.sh` requires some alternative variables to be set.
+
+This should work even on a Mac!
+
+`run-container.sh` has been developed to use the Dockerfile present to run the playbooks and roles inside a RHEL 8 UBI container image. This means you can use run-container.sh to package a new container image on the fly with your changes to the repository, satisfying dependencies, and then map tmp and vars in to the container. In order to enable multiple clusters being run with multiple containers, `run-container.sh` requires some alternative variables to be set.
 
 ```shell
 usage: run-container.sh [-h|--help] | [-v|--verbose] [(-e |--extra=)VARS] \
@@ -31,37 +38,77 @@ usage: run-container.sh [-h|--help] | [-v|--verbose] [(-e |--extra=)VARS] \
   [[path/to/]PLAY[.yml]] [PLAY[.yml]]...
 ```
 
-You should specify `-c CLUSTER` or `--cluster=CLUSTER` to define a container-managed cluster with a friendly name of CLUSTER. In this case, the container images will be tagged as `devsecops-CLUSTER:latest` and when executed, vars will be mapped in from `vars/CLUSTER/`, expecting to be their default names of `common.yml`, `devsecops.yml`, etc. as needed. In this configuration, if you have a local `~/.kube/config` that you have a cached login (for example, as `opentlc-mgr`, you should pass the path to that file with `-k ~/.kube/config` or `--kubeconfig=~/.kube/config`. `run-container.sh` will copy that file into the `tmp/` directory in the appropriate place for your cluster, and `kubeconfig` should _**not be changed**_ from the DEFAULT of `{{ tmp_dir }}/auth/kubeconfig` in `vars/CLUSTER/common.yml`. Because `run-container.sh` stages the kubeconfig in this way, the cached logins from the playbooks will not back-propogate to your local `~/.kube/config`, so follow-on execution of `oc` or `kubectl` on your host system will not 
+You should specify `-c CLUSTER` or `--cluster=CLUSTER` to define a container-managed cluster with a friendly name of CLUSTER. In this case, the container images will be tagged as `devsecops-CLUSTER:latest` and when executed, vars will be mapped in from `vars/CLUSTER/`, expecting to be their default names of `common.yml`, `devsecops.yml`, etc. as needed. In this configuration, if you have a local `~/.kube/config` that you have a cached login (for example, as `opentlc-mgr`, you should pass the path to that file with `-k ~/.kube/config` or `--kubeconfig=~/.kube/config`. `run-container.sh` will copy that file into the `tmp/` directory in the appropriate place for your cluster, and `kubeconfig` should _**not be changed**_ from the DEFAULT of `{{ tmp_dir }}/auth/kubeconfig` in `vars/CLUSTER/common.yml`. Because `run-container.sh` stages the kubeconfig in this way, the cached logins from the playbooks will not back-propogate to your local `~/.kube/config`, so follow-on execution of `oc` or `kubectl` on your host system will not respect any changes executed in the container without using the kubeconfig in `tmp/`.
+
+For example, let's suppose you wanted to use the friendly name `rhpds` for a cluster. You create a directory in `vars/` named `rhpds` and copy the necessary examples into it, while renaming them.
+
+```shell
+mkdir -p vars/rhpds
+cp vars/common.example.yml vars/rhpds/common.yml
+cp vars/devsecops.example.yml vars/rhpds/devsecops.yml
+```
+
+Then edit `vars/rhpds/common.yml` so that cluster_name and openshift_base_domain match the email you got from RHPDS. You will additionally have to set `oc_cli` to the commented-out value of `/usr/local/bin/oc` for the container workflow, if you are not provisioning. **You should not change kubeconfig in common.yml for the container workflow.**
+
+You can edit the rest of `common.yml` and `devsecops.yml` to suit your needs, in their normally documented fashion, for playbook execution inside the container.
+
+If you have not already, log in to your cluster locally before executing the script. To do that, and then build and execute the container image, you can run:
+
+```shell
+oc login -u opentlc-mgr -p <PASSWORD_FROM_EMAIL> <cluster_name>.<openshift_base_domain>         # Make sure you use the values from your email from RHPDS, not these placeholders
+oc whoami                                                                                       # You should see `opentlc-mgr` here
+./run-container.sh -c rhpds -k ~/.kube/config devsecops                                         # ~/.kube/config is the default location for the kubeconfig for kubectl and oc, replace if yours is different
+#                   ^        ^                ^-- this is the name of the playbook you want to execute. It should be in playbooks/devsecops.yml in this case
+#                   |        \---- This is telling run-container.sh to copy the kubeconfig from this location into tmp before running the container image
+#                   \--- this flag lets run-container.sh know what subfolder your vars are in, and what to name the container image
+```
+
+At this point, playbook execution should begin. Before attempting to work on a cluster, you may want to try running the `test` playbook to ensure you get good feedback from the framework.
+
+You can, of course, use the cluster name command line option to define multiple clusters, each with vars in their own subfolders, and execute any playbook from the project in the container. This means you could maintain vars folders for multiple clusters that you provision on the fly and provision or destroy them, as well as deploying the devsecops content on them, independently. They will continue to maintain kubeconfigs in their `tmp` subdirectory, and will all map the `common.yml`, `provision.yml`, and `devsecops.yml`, dynamically into their `vars` folder inside of the container at runtime. Container images will only be rebuilt when the cache expires or a change has been made, so you can continue to make edits and tweaks on the fly while running this workflow.
+
+Do note that the containers run, in a `podman` environment, as your user - without relabelling or remapping them - but on a `docker` environment they are running fully priveleged. This is more privilege than containers normally get in either environment. This is to ensure that the repository files are mappable and editable by the container process as it executes.
 
 ## Basic operation
 
 ### Deployment of an OpenShift cluster
 
 1. For easiest operation, you should create a file at the project root named `.aws` with the following content:
+
    ```shell
    export AWS_ACCESS_KEY_ID=<your actual access key ID>
    export AWS_SECRET_ACCESS_KEY=<your actual access key secret>
    ```
+
    It is in .gitignore, so you won't be committing secrets if you make changes.
 1. Open a terminal and change into the project directory. Source `prep.sh`:
+
    ```shell
    cd openshift-devsecops # or wherever you put the project root
    . prep.sh
    ```
+
 1. Copy the vars examples and edit them to match your desired environment
+
    ```shell
    cp vars/common.example.yml vars/common.yml
    vi vars/common.yml               # Change the appropriate variables
    cp vars/provision.example.yml vars/provision.yml
    vi vars/provision.yml            # Change the appropriate variables
    ```
+
 1. Execute `run.sh` with the names of the playbooks you would like run, in order.
+
    ```shell
    ./run.sh provision
    ```
+
 1. Wait a while. Currently, in my experience, it takes about 35-45 minutes to deploy a cluster.
+
 ### Deployment of workshop on an existing cluster
+
 1. Open a terminal and change into the project directory. Copy the vars examples and edit them to match your desired environment.
+
    ```shell
    cd openshift-devsecops # or wherever you put the project root
    cp vars/common.example.yml vars/common.yml
@@ -69,13 +116,19 @@ You should specify `-c CLUSTER` or `--cluster=CLUSTER` to define a container-man
    cp vars/devsecops.example.yml vars/devsecops.yml
    vi vars/devsecops.yml            # Change the appropriate variables
    ```
+
 1. Execute `run.sh` with the names of the devsecops playbook
+
    ```shell
    ./run.sh devsecops
    ```
-1. Wait a while. Currently, in my experience, it takes about 15-30 minutes to deploy everything I've made so far.
+
+1. Wait a while. Currently, in my experience, it takes about 30 minutes to deploy everything by default.
+
 ### Alternatively, deploy a cluster and the workshop content at once
+
 1. Do all of the above steps for both parts at once.
+
    ```shell
    cd openshift-devsecops # or wherever you put the project root
    . prep.sh
@@ -87,61 +140,81 @@ You should specify `-c CLUSTER` or `--cluster=CLUSTER` to define a container-man
    vi vars/devsecops.yml            # Change the appropriate variables
    ./run.sh provision devsecops
    ```
-1. Wait a while. Currently, in my experience, it takes about an hour to deploy a cluster and everything I've made so far.
+
+1. Wait a while. Currently, in my experience, it takes about an hour to deploy a cluster and everything by default.
+
 ### Access the workshop services if you deployed the cluster from this repo
+
 1. Access the cluster via cli or web console. If this repo deployed your cluster, the `oc` client is downloaded into `tmp`, in a directory named after the cluster, and `prep.sh` can put that into your path. The web console should be available at `https://console.apps.{{ cluster_name }}.{{ openshift_base_domain }}`. If you have recently deployed a cluster, you can update kubeconfig paths and $PATH for running binaries with the following:
+
    ```shell
    cd openshift-devsecops # or wherever you put the project root
    . prep.sh
    ```
+
    prep.sh is aware of multiple clusters and will let you add to PATH and KUBECONFIG on a per-cluster basis in multiple terminals if you would like.
 1. If you deployed the cluster with this repo, when you are ready to tear the cluster down, run the following commands from the project root:
+
    ```shell
    cd openshift-devsecops # or wherever you put the project root
    . prep.sh
    ./run.sh destroy
    ```
+
    If you are using multiple clusters or otherwise non-default vars files locations, you can specify a common.yml path (e.g. with `-e @vars/my_common.yml`) to destroy a specific cluster.
 
 ## Basic Structure
+
 There are three major playbooks implemented currently:
-  - `playbooks/provision.yml`
-  - `playbooks/devescops.yml`
-  - `playbooks/destroy.yml`
+
+- `playbooks/provision.yml`
+- `playbooks/devescops.yml`
+- `playbooks/destroy.yml`
 
 Additionally, there are three important vars files currently:
-  - `vars/provision.yml`
-  - `vars/devsecops.yml`
-  - `vars/common.yml`
+
+- `vars/provision.yml`
+- `vars/devsecops.yml`
+- `vars/common.yml`
 
 There are a significant number of in-flux roles that are part of building the cluster and workshop content. You should explore individual roles on your own, or look at how the playbooks use them to understand their operation. The intent of the final release of this repo is that the roles will be capable of being developed/maintained independently, and they may be split into separate repositories with role depdendency, git submodules, or some combination of the two used to install them from GitHub or another SCM.
 
 ### Playbooks
+
 ---
+
 #### playbooks/provision.yml
+
 This playbook will, given access to AWS keys for an administrator account on which Route53 is managing DNS, provision an OpenShift 4.x cluster using the latest installer for the specified major.minor release.
 Future plans for this playbook:
-  - Implement provisioning for other CCSPs (TBD)
+
+- Implement provisioning for other CCSPs (TBD)
 
 #### playbooks/devescops.yml
+
 This playbook will deploy all of the services to be used in the workshop. First it adjusts the cluster to be ready to accept workshop content by doing the following:
-  - Create htpasswd-backed users based on the vars provided
-  - Delete the kubeadmin default user
-  - Generate and apply LetsEncrypt certificates for both the API endpoint and the default certificate for the OpenShift Router (If you have AWS keys sourced or included in vars)
-  - Enable Machine and Cluster Autoscalers to allow the cluster to remain as small as possible (two 2xlarge instances as workers by default) until a load requires more nodes to be provisioned.
-  - Change the console route to `console.apps.{{ cluster_name }}.{{ openshift_base_domain }}` because `console-openshift-console.apps` was deemed to be _just a bit much_.
+
+- Create htpasswd-backed users based on the vars provided
+- Delete the kubeadmin default user
+- Generate and apply LetsEncrypt certificates for both the API endpoint and the default certificate for the OpenShift Router (If you have AWS keys sourced or included in vars)
+- Enable Machine and Cluster Autoscalers to allow the cluster to remain as small as possible (two 2xlarge instances as workers by default) until a load requires more nodes to be provisioned.
+- Change the console route to `console.apps.{{ cluster_name }}.{{ openshift_base_domain }}` because `console-openshift-console.apps` was deemed to be _just a bit much_.
 
 As a rule, it uses Operators for the provisioning/management of all services. Where an appropriate Operator was available in the default catalog sources, those were used. Where one doesn't exist, they were sourced from Red Hat GPTE published content. Also as a rule, it tries to stand up only one of each service and provision users on each service. The roles have all been designed such that they attempt to deploy sane defaults in the absence of custom variables, but there should be enough configuration available through templated variables that the roles are valuable outside of the scope of this workshop.
 
 The services provided are currently in rapid flux and you should simply look through the listing to see what's applied. For roles to be implemented or changed in the future, please refer to GitHub Issues as these are the tracking mechanism I'm using to keep myself on track.
 
 #### playbooks/destroy.yml
+
 This playbook will, provided a common.yml, identify if openshift-install was run from this host and confirm you would like to remove this cluster. It will completely tear the cluster down, and remove everything from the temporary directory for this cluster.
 
 ### Variable Files
+
 ---
+
 There are example files that may be copied and changed for the variable files. Where deemed necessary, the variables are appropriately commented to explain where you should derive their values from, and what they will do for you.
 If you do not have them named exactly as they are shown, as long as you include a vars_file that sets the <vars_type>_included (eg common_included) using `-e` on the `run.sh` or `ansible-playbook` command line. This means you can name the files differently, and deploy multiple clusters at once. A hypothetical multi-cluster deployment workflow could be like this:
+
    ```shell
    cd openshift-devsecops # or wherever you put the project root
    . prep.sh
@@ -166,13 +239,17 @@ If you do not have them named exactly as they are shown, as long as you include 
    ```
 
 #### vars/common.yml
+
 These variables include things that are important for both an RHPDS-deployed cluster and a cluster deployed from this project. They either define where the cluster is for connection, or they define how to deploy and later connect to the cluster. For clusters created with this project, it also indicates how to destroy the cluster.
 
 #### vars/provision.yml
+
 The primary function of these variables is to provide information necessary to the `provision.yml` playbook for deploymen of the cluster. Future plans for this file align with the future plans for the playbook, intended to enable more infrastrucure platforms.
 
 #### vars/devsecops.yml
+
 This mostly contains switches to enable or disable workshop services and infrastructure. It's also used right now to control from which GitHub project the various GPTE-built operators are sourced.
 
 ## Contributing
+
 I welcome pull requests and issues. I want this to become a valuable tool for Red Hatters at all levels to explore or use for their work, and to be a valuable resource for our partners. If there's something that you think I should do that I'm not, or something that's not working the way you think it was intended, please either let me know or fix it, if you're able. I would love to have help, and as long as we're communicating well via GitHub Issues about the direction that something should go, I won't turn away that help. Please, follow the overall design goals if making a pull request.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ You can, of course, use the cluster name command line option to define multiple 
 
 Do note that the containers run, in a `podman` environment, as your user - without relabelling or remapping them - but on a `docker` environment they are running fully priveleged. This is more privilege than containers normally get in either environment. This is to ensure that the repository files are mappable and editable by the container process as it executes.
 
+Additionally, if you would like to work on just one cluster using the container workflow, you can do any portion of the following the following to skip having to specify these variables or be prompted for them:
+
+```shell
+export DEVSECOPS_CLUSTER=rhpds                                                   # The cluster name for vars directory and container image name
+export AWS_ACCESS_KEY_ID=<YOUR ACTUAL AWS_ACCESS_KEY_ID>                         # Your actual AWS_ACCESS_KEY_ID, which you would otherwise be prompted for if provisioning/destroying a cluster
+export AWS_SECRET_ACCESS_KEY=<YOUR ACTUAL AWS_SECRET_ACCESS_KEY>                 # Your actual AWS_SECRET_ACCESS_KEY, which you would otherwise be prompted for if provisioning/destroying a cluster
+./run-container.sh provision devsecops
+#                    ^---------^----these are just playbook names, like you would normally pass to `run.sh`
+```
+
 ## Basic operation
 
 ### Deployment of an OpenShift cluster

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,7 +10,7 @@ inventory           = inventory
 forks               = 20
 callback_whitelist  = timer, profile_tasks
 
-log_path            = ansible.log
+log_path            = tmp/ansible.log
 roles_path          = roles
 
 retry_files_enabled = False

--- a/playbooks/test.yml
+++ b/playbooks/test.yml
@@ -15,7 +15,7 @@
     - include_vars:
         file: ../vars/common.yml
 # Try to demonstrate vars were read
-    - debug: var=openshift_base_domain
+    - debug: var=full_cluster_name
 # Try to write to tmp for persistence
     - file:
         state: directory
@@ -29,3 +29,4 @@
       changed_when: false
       register: oc_path
     - debug: var=oc_path
+    - debug: var=oc_cli

--- a/playbooks/test.yml
+++ b/playbooks/test.yml
@@ -1,0 +1,31 @@
+---
+- hosts: all
+  tasks:
+# See if facts gathering worked
+    - debug: var=ansible_facts
+# Show directory information
+    - shell: |
+        ls -halFZ {{ playbook_dir }}/.. 2>&1
+        ls -halFZ {{ playbook_dir }}/../tmp 2>&1 ||:
+        ls -halFZ {{ playbook_dir }}/../vars 2>&1 ||:
+      register: dir_listing
+      changed_when: false
+    - debug: msg='{{ dir_listing.stdout }}'
+# Try to include vars
+    - include_vars:
+        file: ../vars/common.yml
+# Try to demonstrate vars were read
+    - debug: var=openshift_base_domain
+# Try to write to tmp for persistence
+    - file:
+        state: directory
+        path: '{{ tmp_dir }}'
+    - file:
+        state: touch
+        path: '{{ tmp_dir }}/test_worked'
+# Identify the OC client
+    - shell: which oc
+      failed_when: false
+      changed_when: false
+      register: oc_path
+    - debug: var=oc_path

--- a/roles/openshift-installer/tasks/prep.yml
+++ b/roles/openshift-installer/tasks/prep.yml
@@ -9,6 +9,7 @@
 
 - name: Register the keypair with the SSH agent
   shell: |
+    eval "$(ssh-agent)"
     if ! ssh-add -l | grep -qF '{{ workshop_admin.username }}@{{ full_cluster_name }}'; then
         ssh-add {{ key_pair_path }} &>/dev/null && echo changed || echo failed
     else

--- a/run-container.sh
+++ b/run-container.sh
@@ -85,8 +85,10 @@ done
 # You have to specify a cluster name, either via export or arg
 if [ -z "$DEVSECOPS_CLUSTER" ]; then
     echo -e "Error: You must specify a cluster.\n$usage" >&2
+    exit 2
 elif [ ! -d "vars/$DEVSECOPS_CLUSTER" ]; then
     echo -e "Error: You must create a subdirectory in $PWD/vars named $cluster with common.yml, devsecops.yml, and provision.yml in it (as needed by your playbooks) to pass into the container.\n$usage" >&2
+    exit 3
 fi
 
 args="$verbose_flag"
@@ -159,7 +161,7 @@ elif [ -r ~/.kube/config ]; then
     cp "$(realpath ~/.kube/config)" "tmp/$full_cluster_name/auth/kubeconfig"
 else
     echo -e "No KUBECONFIG specified, none in default location. Cowardly aborting.\n$usage" >&2
-    exit 2
+    exit 4
 fi
 
 # Serially iterate over every playbook specified

--- a/run-container.sh
+++ b/run-container.sh
@@ -110,10 +110,10 @@ fi
 
 if which podman &>/dev/null; then
     runtime=podman
-    run_args="-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -it --rm -v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared,ro --label=disable --privileged"
+    run_args="-v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared,ro --label=disable"
 elif which docker &>/dev/null; then
     runtime=docker
-    run_args="-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -it --rm -v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled --privileged"
+    run_args="-v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled"
 else
     echo "A container runtime is necessary to execute these playbooks." >&2
     echo "Please install podman or docker." >&2
@@ -139,5 +139,7 @@ if [ "$cluster_kubeconfig" ]; then
 fi
 
 for playbook in "${playbooks[@]}"; do
-    $runtime run ${run_args} devsecops-$DEVSECOPS_CLUSTER ${args} "${extra[@]}" "$playbook" || exit $?
+    $runtime run  -it --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+        --privileged ${run_args} devsecops-$DEVSECOPS_CLUSTER \
+        ${args} "${extra[@]}" "$playbook" || exit $?
 done

--- a/run-container.sh
+++ b/run-container.sh
@@ -110,10 +110,10 @@ fi
 
 if which podman &>/dev/null; then
     runtime=podman
-    run_args="-it --rm -v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared,ro --label=disable --privileged"
+    run_args="-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -it --rm -v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared,ro --label=disable --privileged"
 elif which docker &>/dev/null; then
     runtime=docker
-    run_args="-it --rm -v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled --privileged"
+    run_args="-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -it --rm -v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled --privileged"
 else
     echo "A container runtime is necessary to execute these playbooks." >&2
     echo "Please install podman or docker." >&2

--- a/run-container.sh
+++ b/run-container.sh
@@ -154,8 +154,10 @@ if [ "$cluster_kubeconfig" ]; then
     cp "$cluster_kubeconfig" "tmp/$full_cluster_name/auth/kubeconfig"
 elif [ -r "tmp/$full_cluster_name/auth/kubeconfig" ]; then
     # Everything is wonderful now (maybe)
+    echo >/dev/null
 elif echo "${playbooks[*]}" | grep -qF provision; then
     # We'll make our own kubeconfig
+    echo >/dev/null
 elif [ -r ~/.kube/config ]; then
     echo "[WARN] No KUBECONFIG specified, not provisioning cluster. Grabbing default from $(realpath ~/.kube/config)." >&2
     cp "$(realpath ~/.kube/config)" "tmp/$full_cluster_name/auth/kubeconfig"

--- a/run-container.sh
+++ b/run-container.sh
@@ -113,7 +113,7 @@ if which podman &>/dev/null; then
     run_args="-v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared,ro --label=disable"
 elif which docker &>/dev/null; then
     runtime=docker
-    run_args="-v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled"
+    run_args="-v $PWD/tmp:/app/tmp -v $PWD/vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled"
 else
     echo "A container runtime is necessary to execute these playbooks." >&2
     echo "Please install podman or docker." >&2

--- a/run-container.sh
+++ b/run-container.sh
@@ -110,17 +110,17 @@ fi
 
 if which podman &>/dev/null; then
     runtime=podman
-    run_args="-it --rm -v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared --label=disable --privileged"
+    run_args="-it --rm -v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared,ro --label=disable --privileged"
 elif which docker &>/dev/null; then
     runtime=docker
-    run_args="-it --rm -v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars --security-opt label=disabled --privileged"
+    run_args="-it --rm -v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:ro --security-opt label=disabled --privileged"
 else
     echo "A container runtime is necessary to execute these playbooks." >&2
     echo "Please install podman or docker." >&2
     exit 1
 fi
 
-if echo "${playbooks[*]}" | grep -qF provision; then
+if echo "${playbooks[*]}" | grep -qF provision || echo "${playbooks[*]}" | grep -qF destroy; then
     if [ -z "$AWS_ACCESS_KEY_ID" ]; then
         read -p "Enter your AWS_ACCESS_KEY_ID: " AWS_ACCESS_KEY_ID
     fi

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+thisdir=$(dirname $(realpath $0))
+cd "$thisdir"
+
+verbose_flag=''
+cluster_kubeconfig=''
+extra=()
+playbooks=()
+inventory=''
+
+usage="usage: $(basename $0) [-h|--help] | [-v|--verbose] [(-e |--extra=)VARS] \\
+  (-c |--cluster=)CLUSTER [-k |--kubeconfig=)FILE \\
+  [[path/to/]PLAY[.yml]] [PLAY[.yml]]..."
+
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            cat << EOF >&2
+$usage
+
+    -v|--verbose                Run the ansible-playbook command with the -vvvv
+                                  flag to enable extremely verbose output
+    -e VARS|--extra=VARS        Extra-vars to pass into the playbook
+    -c CLUSTER|--cluster=CLUSER Defines the name of the cluster, for the vars
+                                  directory and container image name.
+    -k FILE|--kubeconfig=FILE   Set a path to a kubeconfig on your host system
+                                  to pass into the container image. It will be
+                                  copied into the tmp directory for this cluster
+                                  prior to bind-mounting the tmp directory.
+    PLAY[.yml]                  You can specify the file name of a playbook
+                                  (with or without the .yml extension) to run.
+                                  If omitted, you will be presented with a menu
+                                  to select your play from if there is more than
+                                  one available. If your playbook is outside of
+                                  the directory 'playbooks/', you can specify
+                                  the absolute path or the path relative to
+                                  run.sh. Multiple playbooks may be specified,
+                                  and they will be run sequentially (halting if
+                                  any playbook fails).
+                                NOTE: Playbooks must be in the 'playbooks/'
+                                  subdirectory in the same path as this script
+                                  to be identified by the menu presented if none
+                                  are provided on the command line.
+EOF
+        exit                                                    ;;
+        -v|--verbose)
+            verbose_flag='-vvvv'                                ;;
+        -e|--extra=*)
+            if [ "$1" == '-e' ]; then
+                shift
+                extra+=('-e' "$1")
+            else
+                extra+=('-e' $(echo "$1" | cut -d= -f2-))
+            fi                                                  ;;
+        -c|--cluster=*)
+            if [ "$1" == '-c' ]; then
+                shift
+                DEVSECOPS_CLUSTER="$1"
+            else
+                DEVSECOPS_CLUSTER=$(echo "$1" | cut -d= -f2-)
+            fi                                                  ;;
+        -k|--kubeconfig=*)
+            if [ "$1" == '-k' ]; then
+                shift
+                cluster_kubeconfig="$1"
+            else
+                cluster_kubeconfig=$(echo "$1" | cut -d= -f2-)
+            fi                                                  ;;
+        *)
+            if [ -f "playbooks/${1}.yml" ]; then
+                playbooks+=("playbooks/${1}.yml")
+            elif [ -f "playbooks/${1}" ]; then
+                playbooks+=("playbooks/${1}")
+            elif [ -f "${1}" ]; then
+                playbooks+=("${1}")
+            else
+                echo -e "Error: $1 appears to be an invalid playbook.\n$usage" >&2
+                exit 1
+            fi                                                  ;;
+    esac
+    shift
+done
+
+if [ -z "$DEVSECOPS_CLUSTER" ]; then
+    echo -e "Error: You must specify a cluster.\n$usage" >&2
+elif [ ! -d "vars/$DEVSECOPS_CLUSTER" ]; then
+    echo -e "Error: You must create a subdirectory in $(pwd)/vars named $cluster with common.yml, devsecops.yml, and provision.yml in it to pass into the container.\n$usage" >&2
+fi
+
+args="$verbose_flag"
+
+if [ -z "${playbooks[*]}" ]; then
+    if [ $(ls playbooks/ | wc -l) -eq 1 ]; then
+        playbooks=("playbooks/$(ls playbooks/)")
+    else
+        echo 'Choose a play to run:'
+        export PS3='> '
+        select choice in $(ls playbooks/ | sed 's/\.yml//g'); do
+            if [ "$choice" ]; then
+                playbooks=("playbooks/${choice}.yml")
+                break
+            else
+                echo "Invalid selection, $REPLY, please select an index position from above." >&2
+            fi
+        done
+    fi
+fi
+
+if which podman &>/dev/null; then
+    runtime=podman
+    run_args="-it --rm -v ./tmp:/app/tmp:shared -v ./vars/$DEVSECOPS_CLUSTER:/app/vars:shared --label=disable --privileged"
+elif which docker &>/dev/null; then
+    runtime=docker
+    run_args="-it --rm -v ./tmp:/app/tmp -v ./vars/$DEVSECOPS_CLUSTER:/app/vars --security-opt label=disabled --privileged"
+else
+    echo "A container runtime is necessary to execute these playbooks." >&2
+    echo "Please install podman or docker." >&2
+    exit 1
+fi
+
+if echo "${playbooks[*]}" | grep -qF provision; then
+    if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+        read -p "Enter your AWS_ACCESS_KEY_ID: " AWS_ACCESS_KEY_ID
+    fi
+    if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+        read -sp "Enter your AWS_SECRET_ACCESS_KEY: " AWS_SECRET_ACCESS_KEY
+    fi
+fi
+
+$runtime build . -t devsecops-$DEVSECOPS_CLUSTER
+
+if [ "$cluster_kubeconfig" ]; then
+    cluster_name=$(awk '/^cluster_name:/{print $2}' vars/$DEVSECOPS_CLUSTER/common.yml)
+    openshift_base_domain=$(awk '/^openshift_base_domain:/{print $2}' vars/$DEVSECOPS_CLUSTER/common.yml)
+    mkdir -p tmp/$cluster_name.$openshift_base_domain/auth
+    cp "$cluster_kubeconfig" "tmp/$cluster_name.$openshift_base_domain/auth/kubeconfig"
+fi
+
+for playbook in "${playbooks[@]}"; do
+    $runtime run ${run_args} devsecops-$DEVSECOPS_CLUSTER ${args} "${extra[@]}" "$playbook" || exit $?
+done

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-thisdir=$(dirname $(realpath $0))
-cd "$thisdir"
+cd $(dirname $(realpath $0))
 
 verbose_flag=''
 cluster_kubeconfig=''

--- a/runreqs.json
+++ b/runreqs.json
@@ -13,6 +13,14 @@
         {
             "pkg": "httpd-tools",
             "bin": "htpasswd"
+        },
+        {
+            "pkg": "openssh-clients",
+            "bin": "ssh-agent"
+        },
+        {
+            "pkg": "git",
+            "bin": "git"
         }
     ]
 }

--- a/vars/common.example.yml
+++ b/vars/common.example.yml
@@ -46,13 +46,16 @@ tmp_dir: '{{ "/".join([ _tmp_parent, full_cluster_name ]) }}'
 #   The default value is what's configured if you're provisioning the workshop
 #   in AWS, RHPDS clusters should use your user's kubeconfig after caching login
 #   credentials with oc.
-# NOTE: Do not use ~ or other shell-expandable variables
+#   NOTE: Do not use ~ or other shell-expandable variables
 # kubeconfig: '{{ ansible_env["HOME"] }}/.kube/config'
+#   NOTE: IF YOU ARE USING run-container.sh:
+# *** DO NOT CHANGE THIS - IT WILL BE PUT HERE BY THE RUN SCRIPT ***
 kubeconfig: '{{ tmp_dir }}/auth/kubeconfig'
 
 # The path to your 'oc' client - the provisioner puts it in {{ tmp_dir }},
 #   for RHPDS clusters, or those being used with the container workflow, you
-#   should specify the absolute path of your oc client.
+#   should specify the absolute path of the oc client. The value commented out
+#   below is the location inside the container for that workflow.
 # oc_cli: '/usr/local/bin/oc'
 oc_cli: '{{ tmp_dir }}/oc'
 

--- a/vars/common.example.yml
+++ b/vars/common.example.yml
@@ -51,7 +51,8 @@ tmp_dir: '{{ "/".join([ _tmp_parent, full_cluster_name ]) }}'
 kubeconfig: '{{ tmp_dir }}/auth/kubeconfig'
 
 # The path to your 'oc' client - the provisioner puts it in {{ tmp_dir }},
-#   for RHPDS clusters you should specify the absolute path of your oc client.
+#   for RHPDS clusters, or those being used with the container workflow, you
+#   should specify the absolute path of your oc client.
 # oc_cli: '/usr/local/bin/oc'
 oc_cli: '{{ tmp_dir }}/oc'
 


### PR DESCRIPTION
Adds alternative run script, more documentation, and a Dockerfile for packaging and running container images on the fly.

Very little security added, this just effectively isolates the runtime environment to a known-good environment on execution, intended to add portability to the environment. It's little more than a quick hack, but should work well for local development.

Tested working on Fedora here, would like two sets of eyes on it if I can get them. Another Linux user of some sort, and a Mac user. If you can test this please let me know and I'll assign you as a reviewer.