### PR TITLE
Update spawner role template to use new custom tab configuration

### DIFF
--- a/roles/workshop-spawner/templates/workshop-spawner.yml.j2
+++ b/roles/workshop-spawner/templates/workshop-spawner.yml.j2
@@ -276,8 +276,8 @@ items:
             value: codeready
           - name: KEYCLOAK_CLIENT_ID
             value: codeready-public
-          - name: CRW_URL
-            value: https://codeready-{{ crw_project_name }}.apps.{{ cluster_name }}.{{ openshift_base_domain }}
+          - name: CUSTOM_TAB_1
+            value: "CodeReady Workspaces=https://codeready-{{ crw_project_name }}.apps.{{ cluster_name }}.{{ openshift_base_domain }}"
           - name: API_SERVER
             value: https://api.{{ cluster_name }}.{{ openshift_base_domain }}:6443
           livenessProbe:


### PR DESCRIPTION
This should *only* be merged after [this PR](https://github.com/jharmison-redhat/workshop-spawner/pull/2) and [this PR](https://github.com/jharmison-redhat/workshop-dashboard/pull/1) are merged, and container images built.

@jharmison-redhat: I assume your working changes include updating the `spawner` and `dashboard` images [here](https://github.com/jharmison-redhat/openshift-devsecops/blob/master/roles/workshop-spawner/defaults/main.yml#L5) to use quay.io/redhatgov ones, so I haven't included that change here. 