### PR TITLE
Fix letsencrypt

### DIFF
--- a/roles/cluster-adjuster/tasks/main.yml
+++ b/roles/cluster-adjuster/tasks/main.yml
@@ -11,11 +11,15 @@
   when:
     - letsencrypt
     - AWS_ACCESS_KEY_ID is defined or ansible_env["AWS_ACCESS_KEY_ID"] is defined
+    - AWS_ACCESS_KEY_ID|default("") != "" or ansible_env["AWS_ACCESS_KEY_ID"]|default("") != ""
+
 - include_tasks: byo_cert.yml
   when:
     - not letsencrypt
     - byo_cert_fullchain_path is defined
+    - byo_cert_fullchain_path != ""
     - byo_cert_key_path is defined
+    - byo_cert_key_path != ""
 
 - include_tasks: autoscale.yml
   when: autoscale

--- a/roles/quay/tasks/certificates.yml
+++ b/roles/quay/tasks/certificates.yml
@@ -1,0 +1,18 @@
+---
+- name: Download acme.sh
+  git:
+    repo: https://github.com/neilpang/acme.sh
+    dest: '{{ _tmp_parent }}/acme.sh'
+
+- name: Ensure certificate directory exists
+  file:
+    path: '{{ certificate_path }}'
+    state: directory
+
+- name: Get necessary certs
+  shell: '{{ lookup("template", "quay_certs.sh.j2") }}'
+  args:
+    creates: '{{ certificate_path }}/quay-fullchain.pem'
+  environment:
+    AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID|default(ansible_env["AWS_ACCESS_KEY_ID"]) }}'
+    AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY|default(ansible_env["AWS_SECRET_ACCESS_KEY"]) }}'

--- a/roles/quay/tasks/main.yml
+++ b/roles/quay/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
+- name: Determine if we should do quay certs
+  set_fact:
+    do_quay_certs: (letsencrypt|bool and (AWS_ACCESS_KEY_ID is defined or ansible_env["AWS_ACCESS_KEY_ID"] is defined) and (AWS_ACCESS_KEY_ID|default("") != "" or ansible_env["AWS_ACCESS_KEY_ID"]|default("") != ""))|bool
+
 - include_tasks: certificates.yml
-  when:
-    - letsencrypt
-    - AWS_ACCESS_KEY_ID is defined or ansible_env["AWS_ACCESS_KEY_ID"] is defined
-    - AWS_ACCESS_KEY_ID|default("") != "" or ansible_env["AWS_ACCESS_KEY_ID"]|default("") != ""
+  when: '{{ do_quay_certs }}'
 
 - name: Subscribe to Quay Enterprise
   k8s:

--- a/roles/quay/tasks/main.yml
+++ b/roles/quay/tasks/main.yml
@@ -1,30 +1,9 @@
 ---
-- name: Download acme.sh
-  git:
-    repo: https://github.com/neilpang/acme.sh
-    dest: '{{ _tmp_parent }}/acme.sh'
+- include_tasks: certificates.yml
   when:
     - letsencrypt
     - AWS_ACCESS_KEY_ID is defined or ansible_env["AWS_ACCESS_KEY_ID"] is defined
-
-- name: Ensure certificate directory exists
-  file:
-    path: '{{ certificate_path }}'
-    state: directory
-  when:
-    - letsencrypt
-    - AWS_ACCESS_KEY_ID is defined or ansible_env["AWS_ACCESS_KEY_ID"] is defined
-
-- name: Get necessary certs
-  shell: '{{ lookup("template", "quay_certs.sh.j2") }}'
-  args:
-    creates: '{{ certificate_path }}/quay-fullchain.pem'
-  environment:
-    AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID|default(ansible_env["AWS_ACCESS_KEY_ID"]) }}'
-    AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY|default(ansible_env["AWS_SECRET_ACCESS_KEY"]) }}'
-  when:
-    - letsencrypt
-    - AWS_ACCESS_KEY_ID is defined or ansible_env["AWS_ACCESS_KEY_ID"] is defined
+    - AWS_ACCESS_KEY_ID|default("") != "" or ansible_env["AWS_ACCESS_KEY_ID"]|default("") != ""
 
 - name: Subscribe to Quay Enterprise
   k8s:

--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -52,7 +52,7 @@
     superuser-password: {{ quay_password }}
     superuser-email: quay@redhat.com
 
-{% if do_quay_certs %}
+{% if do_quay_certs|bool %}
 # Secret to use cluster certs for Quay
 - apiVersion: v1
   kind: Secret

--- a/roles/quay/templates/quay.yml.j2
+++ b/roles/quay/templates/quay.yml.j2
@@ -52,7 +52,7 @@
     superuser-password: {{ quay_password }}
     superuser-email: quay@redhat.com
 
-{% if (letsencrypt|default(true)) %}
+{% if do_quay_certs %}
 # Secret to use cluster certs for Quay
 - apiVersion: v1
   kind: Secret

--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -13,7 +13,7 @@ spec:
 {% endif %}
     externalAccess:
       hostname: {{ quay_route }}
-{% if (letsencrypt|default(true)) %}
+{% if do_quay_certs %}
       tls:
         secretName: quay-tls-certs
         termination: passthrough

--- a/roles/quay/templates/quay_cr.yml.j2
+++ b/roles/quay/templates/quay_cr.yml.j2
@@ -13,7 +13,7 @@ spec:
 {% endif %}
     externalAccess:
       hostname: {{ quay_route }}
-{% if do_quay_certs %}
+{% if do_quay_certs|bool %}
       tls:
         secretName: quay-tls-certs
         termination: passthrough


### PR DESCRIPTION
closes #70 

This was tested to work on RHPDS, except for `qui-gon` problems. Testing conditions:

* RHPDS cluster
* Normal run-container.sh workflow with `oc` cached login
* `letsencrypt` not specified at all in any vars file
* Quay turned on

I can confirm that after the first commit I had more of the same failures people have been getting, then I cleaned up in the second commit and sailed through until ImagePullBackOff :)